### PR TITLE
Maintain both internal $infomon_bound state and Spell[214] state

### DIFF
--- a/lib/infomon.lic
+++ b/lib/infomon.lic
@@ -1222,6 +1222,9 @@ while line = get
         else
           servant_type = nil
         end
+      elsif spell.num == 214
+        spell.putup
+        $infomon_bound = true
       elsif spell.num == 9812
         if line =~ /^With difficulty, you manage to will yourself into the space between the corporeal and ethereal realms\.$/
           $infomon_transcendance_emergency = true
@@ -1434,6 +1437,9 @@ while line = get
           if (recovery = Spell[599]) and (recovery.timeleft > 0)
             respond "[ #{recovery.name}: +#{recovery.timeleft.as_time}, #{recovery.remaining} remaining. ]" if CharSettings['show_messages']
           end
+        elsif spell.num == 214
+          spell.putdown
+          $infomon_bound = false
         else
           spell.putdown
         end

--- a/lib/spell-list.xml
+++ b/lib/spell-list.xml
@@ -201,9 +201,9 @@
    </spell>
    <spell availability='all' name='Bind' number='214' type='attack'>
       <cost type='mana'>14</cost>
-      <duration cast-type='target' span='stackable'>if (history = reget.reverse) and (line = history.index { |l| l =~ /^An unseen force envelopes you, restricting all movement\./ }) and history[history.index(line)+2] =~ /^\s*CS: [\+\-][0-9]+ \- TD\: [\+\-][0-9]+ \+ CvA\: [\+\-][0-9]+ \+ d100\: [\+\-][0-9]+ (?:\- \+?[0-9]+ )?==? \+([0-9]+)/; 13 + ($1.to_i - 100)/60.0; else; 0.25; end</duration>
-      <duration cast-type='self' span='stackable'>if (history = reget.reverse) and (line = history.index { |l| l =~ /^An unseen force envelopes you, restricting all movement\./ }) and history[history.index(line)+2] =~ /^\s*CS: [\+\-][0-9]+ \- TD\: [\+\-][0-9]+ \+ CvA\: [\+\-][0-9]+ \+ d100\: [\+\-][0-9]+ (?:\- \+?[0-9]+ )?==? \+([0-9]+)/; 13 + ($1.to_i - 100)/60.0; else; 0.25; end</duration>
-      <message type='start'>An unseen force envelopes you, restricting all movement\.</message>
+      <duration cast-type='target' span='stackable'>if (history = reget.reverse) and (line = history.index { |l| l =~ /^An unseen force envelops you, restricting all movement\./ }) and history[history.index(line)+2] =~ /^\s*CS: [\+\-][0-9]+ \- TD\: [\+\-][0-9]+ \+ CvA\: [\+\-][0-9]+ \+ d100\: [\+\-][0-9]+ (?:\- \+?[0-9]+ )?==? \+([0-9]+)/; 13 + ($1.to_i - 100)/60.0; else; 0.25; end</duration>
+      <duration cast-type='self' span='stackable'>if (history = reget.reverse) and (line = history.index { |l| l =~ /^An unseen force envelops you, restricting all movement\./ }) and history[history.index(line)+2] =~ /^\s*CS: [\+\-][0-9]+ \- TD\: [\+\-][0-9]+ \+ CvA\: [\+\-][0-9]+ \+ d100\: [\+\-][0-9]+ (?:\- \+?[0-9]+ )?==? \+([0-9]+)/; 13 + ($1.to_i - 100)/60.0; else; 0.25; end</duration>
+      <message type='start'>An unseen force envelops you, restricting all movement\.</message>
       <message type='end'>The restricting force that envelops you dissolves away\.</message>
    </spell>
    <spell availability='group' name='Heroism' number='215' type='offense'>


### PR DESCRIPTION
Pretty sure checkbound has been broken since someone added it to the spell list to be tracked as `Spell[214].active?`. This updates the up message in spell-list.xml and infomon to update the state in both places when it sees those lines.