### PR TITLE
spell-list: make 909 self-cast only

### DIFF
--- a/lib/spell-list.xml
+++ b/lib/spell-list.xml
@@ -889,7 +889,7 @@
    <spell availability='all' name='Major Fire' number='908' channel='yes' stance='yes' type='attack'>
       <cost type='mana'>8</cost>
    </spell>
-   <spell availability='all' name='Tremors' number='909' type='attack/area/utility'>
+   <spell availability='self-cast' name='Tremors' number='909' type='attack/area/utility'>
       <duration span='refreshable' multicastable='no'>20 + Spells.wizard</duration>
       <cost type='mana'>9</cost>
       <message type='start'>Faint ripples in the (?:dirt|floor|ground|ice|muck|sand|snow|soil) form beneath you for a moment\.</message>


### PR DESCRIPTION
This prevents people from accidentally casting it as the attack spell
version if its enabled in ;waggle. This also works fine with the open
cast version since casting on yourself is ideal as it affects the area
and not individual monsters.