### PR TITLE
Update spell-list.xml for OSA tasks

### DIFF
--- a/lib/spell-list.xml
+++ b/lib/spell-list.xml
@@ -2092,7 +2092,8 @@
       <duration persist-on-death='yes' real-time='yes'>15</duration>
       <message type='start'>[A-Z][a-z]+ says, &quot;Hmm, I&apos;ve got a task here|^[A-Z][a-z]+ says, &quot;I&apos;ve got a special mission for you.*</message>
       <message type='start'>You reach for the large board and select a posted task at random\.</message>
-      <message type='start'>You were tasked with (?:hunting|sinking|slaying) </message>
+      <message type='start'>^You were tasked with (?:hunting|sinking) </message>
+      <message type='start'>^You were tasked with slaying [0-9]+ pirates\.</message>
    </spell>
    <spell availability='self-cast' name='Next Group Bounty' number='9056' type='timer'>
       <duration persist-on-death='yes' real-time='yes'>15</duration>

--- a/lib/spell-list.xml
+++ b/lib/spell-list.xml
@@ -2091,6 +2091,7 @@
    <spell availability='self-cast' name='Next Bounty' number='9003' type='timer'>
       <duration persist-on-death='yes' real-time='yes'>15</duration>
       <message type='start'>[A-Z][a-z]+ says, &quot;Hmm, I&apos;ve got a task here|^[A-Z][a-z]+ says, &quot;I&apos;ve got a special mission for you.*</message>
+      <message type='start'>You reach for the large board and select a posted task at random\.</message>	 
    </spell>
    <spell availability='self-cast' name='Next Group Bounty' number='9056' type='timer'>
       <duration persist-on-death='yes' real-time='yes'>15</duration>

--- a/lib/spell-list.xml
+++ b/lib/spell-list.xml
@@ -2091,7 +2091,8 @@
    <spell availability='self-cast' name='Next Bounty' number='9003' type='timer'>
       <duration persist-on-death='yes' real-time='yes'>15</duration>
       <message type='start'>[A-Z][a-z]+ says, &quot;Hmm, I&apos;ve got a task here|^[A-Z][a-z]+ says, &quot;I&apos;ve got a special mission for you.*</message>
-      <message type='start'>You reach for the large board and select a posted task at random\.</message>	 
+      <message type='start'>You reach for the large board and select a posted task at random\.</message>
+      <message type='start'>You were tasked with (?:hunting|sinking|slaying) </message>
    </spell>
    <spell availability='self-cast' name='Next Group Bounty' number='9056' type='timer'>
       <duration persist-on-death='yes' real-time='yes'>15</duration>


### PR DESCRIPTION
Added a new message start entry for 9003 to cover getting an OSA task from the KF board.

We still need to cover the use case where someone uses a Ship Bird, but I'm not certain how to do so. The problem with that use-case is that the messaging for turning in a task and getting a task are identical:

> You read over the Clown note and it crumbles away.

versus

> You read over the Clown note and it crumbles away.
>   You have earned some experience.
>   You have earned some fame.
>   You have earned some notoriety.