### PR TITLE
spell-list.xml add mstrike fire msgup for cooldown

### DIFF
--- a/lib/spell-list.xml
+++ b/lib/spell-list.xml
@@ -2134,7 +2134,7 @@
    </spell>
    <spell availability='all' name='MStrike Cooldown' number='9005' type='timer'>
       <duration>1</duration>
-      <message type='start'>Your (?:flurry|series) of strikes(?: and ripostes)? leaves you (?:off-balance|winded) and out of position\.</message>
+      <message type='start'>Your (?:flurry|series) of (?:strikes|rapid shots)(?: and (?:ripostes|maneuvers))? leaves you (?:off-balance|winded) and out of position\.</message>
       <message type='end'>You feel recovered from your whirlwind flurry of strikes\.</message>
    </spell>
    <spell availability='all' name='Lichbane' number='9006' type='defense'>


### PR DESCRIPTION
```
>mstrike fire dude confirm
You concentrate intently, focusing all your energies.
<snip>
Your series of rapid shots and maneuvers leaves you winded and out of position.
Roundtime: 8 sec.
[ MStrike Cooldown: +0:00:19, 0:00:19 remaining. ]

>mstrike attack dude confirm
You concentrate intently, focusing all your energies.
You explode into a fury of strikes and ripostes, moving with a singular purpose and will!
<snip>
Your series of strikes and ripostes leaves you winded and out of position.
Roundtime: 5 sec.
[ MStrike Cooldown: +0:00:19, 0:00:19 remaining. ]

>mstrike jab dude confirm
You concentrate intently, focusing all your energies.
<snip>
Your series of strikes and ripostes leaves you winded and out of position.
Roundtime: 5 sec.
[ MStrike Cooldown: +0:00:19, 0:00:19 remaining. ]
```

Tested and works for open and focused of all 3 types as far as I can see.