### PR TITLE
[go2.lic] for the COMBAT verb update

### DIFF
--- a/lib/go2.lic
+++ b/lib/go2.lic
@@ -9,10 +9,12 @@
    original author: Shaelun
               game: any
               tags: core, movement
-           version: 1.26
+           version: 1.27
           required: Lich >= 4.6.14
 
    changelog:
+      1.27 (2021-10-29):
+        Fix lag check after COMBATANT verb was updated
       1.26 (2020-10-08):
         Fix silver check broken by Commageddon
       1.25 (2019-05-11):
@@ -952,9 +954,8 @@ loop {
       break if Room.current.id == destination.id
       echo 'restarting script...'
       if error_count > 1
-         # dothis 'help lag-check', /^No help files matching that entry were found\.|^MERCHANT HELP/
          if XMLData.game =~ /^GS/
-            dothis 'combatant', /^That only works in the Gladiator Arenas\./
+            dothistimeout 'help lag-check', 5, /^No help files matching that entry were found\./
          else
             sleep 5
          end


### PR DESCRIPTION
```
>;go2 276
[Town Square, Northwest (the town of Wehnimer's Landing) - 227]
You notice a polished granite statue and an ivy-covered white monir tower.
Obvious paths: north, east, southeast, south
[go2]>none
Please rephrase that command.
[go2: restarting script...]
[go2: ETA: 0:00:00 (1 rooms to move through)]
[go2: move: no direction given]
[go2: restarting script...]
[go2: ETA: 0:00:00 (1 rooms to move through)]
[go2: move: no direction given]
[go2: restarting script...]
[go2]>help lag-check
No help files matching that entry were found.
[go2: ETA: 0:00:00 (1 rooms to move through)]
[go2: move: no direction given]
[go2: changing Room[227].timeto['276'] to nil]
Shinsakuto just arrived.
Shinsakuto just went south.
[go2: restarting script...]
[go2]>help lag-check
No help files matching that entry were found.
[go2: ETA: 0:00:01 (5 rooms to move through)]
[go2]>south
[Town Square, West (the town of Wehnimer's Landing) - 285]
You notice the First Elanith bank.
Obvious paths: north, east, south, west
[go2]>south
[go2]>east
[go2]>north
[go2]>north
[Town Square, Southwest (the town of Wehnimer's Landing) - 284]
You notice a chaotic crimson portal, a wood-sided shop and a cobblestone walkway leading up to a wrought iron gate.
Obvious paths: north, northeast, east, south, west
[Town Square, Southeast (the town of Wehnimer's Landing) - 276]
You notice a mushy black door and a large ebon gate filled with swirling mist.
Obvious paths: north, south, west, northwest
[Town Square, East (the town of Wehnimer's Landing) - 276]
You notice a large purple wooden barrel.
Obvious paths: north, east, south, west
[Town Square, Northeast (the town of Wehnimer's Landing) - 276]
You notice a narrow alleyway.
Obvious paths: east, south, southwest, west
[go2: travel time: 0:00:11]
[go2: reverting Room[227].timeto['276'] back to 0.2]
--- Lich: go2 has exited.
```

updated to use the `help lag-check` dummy command instead of the COMBATANT verb. Temporarily broke a room exit and tested above. (sent a similar PR into go2 on tilmen repo look forward to that being merged sometime in 2078)

Also changed it do a 5 second `dothistimeout` so it doesn't ever potentially hang forever.